### PR TITLE
fee-sweeper: index-fees: Implement initial skeleton

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -12,3 +12,8 @@ Cargo.lock
 
 # MSVC Windows builds of rustc generate these, which store debugging information
 *.pdb
+
+
+# Added by cargo
+
+/target

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,0 +1,25 @@
+[package]
+name = "fee-sweeper"
+version = "0.1.0"
+edition = "2021"
+
+[dependencies]
+# === CLI + Runtime === #
+clap = { version = "4.5.3", features = ["derive", "env"] }
+tokio = { version = "1.10", features = ["full"] }
+
+# === Blockchain Interaction === #
+alloy-sol-types = "0.3.1"
+ethers = "2"
+
+# === Renegade Dependencies === #
+arbitrum-client = { git = "https://github.com/renegade-fi/renegade.git", features = [
+    "rand",
+] }
+renegade-constants = { package = "constants", git = "https://github.com/renegade-fi/renegade.git" }
+renegade-circuit-types = { package = "circuit-types", git = "https://github.com/renegade-fi/renegade.git" }
+renegade-crypto = { git = "https://github.com/renegade-fi/renegade.git" }
+renegade-util = { package = "util", git = "https://github.com/renegade-fi/renegade.git" }
+
+# === Misc Dependencies === #
+futures = "0.3"

--- a/src/index_fees.rs
+++ b/src/index_fees.rs
@@ -1,0 +1,92 @@
+//! Phase one of the sweeper's execution; index all fees since the last consistent block
+
+use alloy_sol_types::SolCall;
+use arbitrum_client::abi::settleOfflineFeeCall;
+use arbitrum_client::{
+    abi::NotePostedFilter, constants::SELECTOR_LEN,
+    helpers::parse_note_ciphertext_from_settle_offline_fee,
+};
+use ethers::contract::LogMeta;
+use ethers::middleware::Middleware;
+use renegade_circuit_types::elgamal::ElGamalCiphertext;
+use renegade_circuit_types::native_helpers::elgamal_decrypt;
+use renegade_circuit_types::note::{Note, NOTE_CIPHERTEXT_SIZE};
+use renegade_circuit_types::wallet::NoteCommitment;
+use renegade_constants::Scalar;
+use renegade_crypto::fields::{scalar_to_biguint, scalar_to_u128, u256_to_scalar};
+use renegade_util::raw_err_str;
+
+use crate::Indexer;
+
+impl Indexer {
+    /// Index all fees since the given block
+    pub async fn index_fees(&self, block_number: u64) -> Result<(), String> {
+        let filter = self
+            .client
+            .get_darkpool_client()
+            .event::<NotePostedFilter>()
+            .from_block(block_number);
+
+        let events = filter
+            .query_with_meta()
+            .await
+            .map_err(raw_err_str!("failed to create note posted stream: {}"))?;
+
+        for (event, meta) in events {
+            let note_comm = u256_to_scalar(&event.note_commitment);
+            self.index_note(note_comm, meta).await?;
+        }
+
+        Ok(())
+    }
+
+    /// Index a note
+    async fn index_note(&self, note_comm: NoteCommitment, meta: LogMeta) -> Result<(), String> {
+        // Parse the note from the tx
+        let tx = self
+            .client
+            .get_darkpool_client()
+            .client()
+            .get_transaction(meta.transaction_hash)
+            .await
+            .map_err(raw_err_str!("failed to query tx: {}"))?
+            .ok_or_else(|| format!("tx not found: {}", meta.transaction_hash))?;
+
+        let calldata: Vec<u8> = tx.input.to_vec();
+        let selector: [u8; 4] = calldata[..SELECTOR_LEN].try_into().unwrap();
+        let encryption = match selector {
+            <settleOfflineFeeCall as SolCall>::SELECTOR => {
+                parse_note_ciphertext_from_settle_offline_fee(&calldata)
+                    .map_err(raw_err_str!("failed to parse ciphertext: {}"))?
+            }
+            sel => return Err(format!("invalid selector when parsing note: {sel:?}")),
+        };
+
+        // Decrypt the note and check that the commitment matches the expected value; if not we are not the receiver
+        let note = self.decrypt_note(&encryption);
+        if note.commitment() != note_comm {
+            println!("not receiver, skipping");
+            return Ok(());
+        }
+
+        // Otherwise, index the note
+        // TODO: Write the note info to the DB
+        println!("indexed note: {note:?}");
+
+        Ok(())
+    }
+
+    /// Decrypt a note using the decryption key
+    fn decrypt_note(&self, note: &ElGamalCiphertext<NOTE_CIPHERTEXT_SIZE>) -> Note {
+        // The ciphertext stores all note values except the encryption key
+        let cleartext_values: [Scalar; NOTE_CIPHERTEXT_SIZE] =
+            elgamal_decrypt(note, &self.decryption_key);
+
+        Note {
+            mint: scalar_to_biguint(&cleartext_values[0]),
+            amount: scalar_to_u128(&cleartext_values[1]),
+            receiver: self.decryption_key.public_key(),
+            blinder: cleartext_values[2],
+        }
+    }
+}

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,0 +1,91 @@
+//! The fee sweeper, sweeps for unredeemed fees in the Renegade protocol and redeems them
+#![deny(missing_docs)]
+#![deny(clippy::missing_docs_in_private_items)]
+#![deny(unsafe_code)]
+#![deny(clippy::needless_pass_by_ref_mut)]
+
+pub mod index_fees;
+use ethers::signers::LocalWallet;
+use renegade_circuit_types::elgamal::DecryptionKey;
+
+use std::{error::Error, str::FromStr};
+
+use arbitrum_client::{
+    client::{ArbitrumClient, ArbitrumClientConfig},
+    constants::Chain,
+};
+use clap::Parser;
+
+/// The block polling interval for the Arbitrum client
+const BLOCK_POLLING_INTERVAL_MS: u64 = 100;
+
+/// The cli for the fee sweeper
+#[derive(Debug, Parser)]
+struct Cli {
+    /// The Arbitrum RPC url to use
+    #[clap(short, long)]
+    rpc_url: String,
+    /// The address of the darkpool contract
+    #[clap(short = 'a', long)]
+    darkpool_address: String,
+    /// The chain to redeem fees for
+    #[clap(long, default_value = "mainnet")]
+    chain: Chain,
+    /// The fee decryption key to use
+    #[clap(short, long)]
+    decryption_key: String,
+    /// The arbitrum private key used to submit transactions
+    #[clap(long = "pkey")]
+    arbitrum_private_key: String,
+}
+
+/// Stores the dependencies needed to index the chain
+pub(crate) struct Indexer {
+    /// The Arbitrum client
+    pub client: ArbitrumClient,
+    /// The decryption key
+    pub decryption_key: DecryptionKey,
+}
+
+impl Indexer {
+    /// Constructor
+    pub fn new(client: ArbitrumClient, decryption_key: DecryptionKey) -> Self {
+        Indexer {
+            client,
+            decryption_key,
+        }
+    }
+}
+
+/// Main
+#[tokio::main]
+async fn main() -> Result<(), Box<dyn Error>> {
+    let cli = Cli::parse();
+
+    // The last block
+    // TODO: Query the DB for this value
+    let last_block = 0;
+
+    // Build an Arbitrum client
+    let wallet = LocalWallet::from_str(&cli.arbitrum_private_key)?;
+    let conf = ArbitrumClientConfig {
+        darkpool_addr: cli.darkpool_address,
+        chain: cli.chain,
+        rpc_url: cli.rpc_url,
+        arb_priv_keys: vec![wallet],
+        block_polling_interval_ms: BLOCK_POLLING_INTERVAL_MS,
+    };
+    let client = ArbitrumClient::new(conf).await?;
+
+    // Build the indexer
+    let key = DecryptionKey::from_hex_str(&cli.decryption_key)?;
+    let indexer = Indexer::new(client, key);
+
+    // 1. Index all new fees in the DB
+    indexer.index_fees(last_block).await?;
+
+    // 2. Redeem fees according to the redemption policy
+    // TODO: Implement this
+
+    Ok(())
+}


### PR DESCRIPTION
### Purpose
This PR initializes the logic for the `fee-sweeper` which sweeps the transaction history of the Renegade protocol and:
1. Indexes fees due to the recipient
2. Redeems fees that are deemed valuable or otherwise ready for redemption 

This PR implements the first chunk of task #1 above. Much of the skeleton is unimplemented.

### Testing
- Connected the sweeper to testnet and gave it a recent last block and the relayer's decryption key. Paid fees for a balance on `trade.renegade.fi` and verified that notes were correctly decrypted and logged _only for the relayer key_.