### PR TITLE
migrations: Setup migrations and create `fees` & `last_indexed` tables

### DIFF
--- a/migrations/2024-06-15-202249_create_last_indexed_table/down.sql
+++ b/migrations/2024-06-15-202249_create_last_indexed_table/down.sql
@@ -1,0 +1,2 @@
+-- Drop the indexing metadata table
+DROP TABLE IF EXISTS indexing_metadata;

--- a/migrations/2024-06-15-202249_create_last_indexed_table/up.sql
+++ b/migrations/2024-06-15-202249_create_last_indexed_table/up.sql
@@ -1,0 +1,7 @@
+-- Create the table that stores indexing metadata
+CREATE TABLE indexing_metadata (
+    latest_block INTEGER
+);
+
+-- Insert a row with the latest block number set to zero
+INSERT INTO indexing_metadata (latest_block) VALUES (0);

--- a/migrations/2024-06-15-203503_create_fees_table/down.sql
+++ b/migrations/2024-06-15-203503_create_fees_table/down.sql
@@ -1,0 +1,4 @@
+-- Drop the fees table and indexes
+DROP TABLE IF EXISTS fees;
+DROP INDEX IF EXISTS idx_fees_mint;
+DROP INDEX IF EXISTS idx_fees_amount;

--- a/migrations/2024-06-15-203503_create_fees_table/up.sql
+++ b/migrations/2024-06-15-203503_create_fees_table/up.sql
@@ -1,0 +1,12 @@
+-- Stores fees and index by mint, amount
+CREATE TABLE fees(
+    id SERIAL PRIMARY KEY,
+    tx_hash TEXT NOT NULL,
+    mint TEXT NOT NULL,
+    amount NUMERIC NOT NULL,
+    blinder NUMERIC NOT NULL,
+    receiver TEXT NOT NULL
+);
+
+CREATE INDEX idx_fees_mint ON fees(mint);
+CREATE INDEX idx_fees_amount ON fees(amount);


### PR DESCRIPTION
### Purpose
This PR sets up a diesel migration directory and adds two migrations which:
1. Add the `indexing_metadata` table
2. Add the `fees` table with indices on the `mint` and `amount` fields

### Testing
- Applied the migrations against the DB