### PR TITLE
migrations: Setup migrations and create `fees` & `last_indexed` tables

### DIFF
--- a/diesel.toml
+++ b/diesel.toml
@@ -1,0 +1,9 @@
+# For documentation on how to configure this file,
+# see https://diesel.rs/guides/configuring-diesel-cli
+
+[print_schema]
+file = "src/schema.rs"
+custom_type_derives = ["diesel::query_builder::QueryId", "Clone"]
+
+[migrations_directory]
+dir = "./migrations"

--- a/migrations/00000000000000_diesel_initial_setup/down.sql
+++ b/migrations/00000000000000_diesel_initial_setup/down.sql
@@ -1,0 +1,6 @@
+-- This file was automatically created by Diesel to setup helper functions
+-- and other internal bookkeeping. This file is safe to edit, any future
+-- changes will be added to existing projects as new migrations.
+
+DROP FUNCTION IF EXISTS diesel_manage_updated_at(_tbl regclass);
+DROP FUNCTION IF EXISTS diesel_set_updated_at();

--- a/migrations/00000000000000_diesel_initial_setup/up.sql
+++ b/migrations/00000000000000_diesel_initial_setup/up.sql
@@ -1,0 +1,36 @@
+-- This file was automatically created by Diesel to setup helper functions
+-- and other internal bookkeeping. This file is safe to edit, any future
+-- changes will be added to existing projects as new migrations.
+
+
+
+
+-- Sets up a trigger for the given table to automatically set a column called
+-- `updated_at` whenever the row is modified (unless `updated_at` was included
+-- in the modified columns)
+--
+-- # Example
+--
+-- ```sql
+-- CREATE TABLE users (id SERIAL PRIMARY KEY, updated_at TIMESTAMP NOT NULL DEFAULT NOW());
+--
+-- SELECT diesel_manage_updated_at('users');
+-- ```
+CREATE OR REPLACE FUNCTION diesel_manage_updated_at(_tbl regclass) RETURNS VOID AS $$
+BEGIN
+    EXECUTE format('CREATE TRIGGER set_updated_at BEFORE UPDATE ON %s
+                    FOR EACH ROW EXECUTE PROCEDURE diesel_set_updated_at()', _tbl);
+END;
+$$ LANGUAGE plpgsql;
+
+CREATE OR REPLACE FUNCTION diesel_set_updated_at() RETURNS trigger AS $$
+BEGIN
+    IF (
+        NEW IS DISTINCT FROM OLD AND
+        NEW.updated_at IS NOT DISTINCT FROM OLD.updated_at
+    ) THEN
+        NEW.updated_at := current_timestamp;
+    END IF;
+    RETURN NEW;
+END;
+$$ LANGUAGE plpgsql;

--- a/migrations/2024-06-15-202249_create_last_indexed_table/down.sql
+++ b/migrations/2024-06-15-202249_create_last_indexed_table/down.sql
@@ -1,0 +1,2 @@
+-- Drop the indexing metadata table
+DROP TABLE IF EXISTS indexing_metadata;

--- a/migrations/2024-06-15-202249_create_last_indexed_table/up.sql
+++ b/migrations/2024-06-15-202249_create_last_indexed_table/up.sql
@@ -1,0 +1,8 @@
+-- Create the table that stores indexing metadata
+CREATE TABLE indexing_metadata (
+    key TEXT PRIMARY KEY,
+    value TEXT NOT NULL
+);
+
+-- Insert a row with the latest block number set to zero
+INSERT INTO indexing_metadata (key, value) VALUES ('latest_block', '0');

--- a/migrations/2024-06-15-203503_create_fees_table/down.sql
+++ b/migrations/2024-06-15-203503_create_fees_table/down.sql
@@ -1,0 +1,4 @@
+-- Drop the fees table and indexes
+DROP TABLE IF EXISTS fees;
+DROP INDEX IF EXISTS idx_fees_mint;
+DROP INDEX IF EXISTS idx_fees_amount;

--- a/migrations/2024-06-15-203503_create_fees_table/up.sql
+++ b/migrations/2024-06-15-203503_create_fees_table/up.sql
@@ -1,0 +1,13 @@
+-- Stores fees and index by mint, amount
+CREATE TABLE fees(
+    id SERIAL PRIMARY KEY,
+    tx_hash TEXT NOT NULL UNIQUE,
+    mint TEXT NOT NULL,
+    amount NUMERIC NOT NULL,
+    blinder NUMERIC NOT NULL,
+    receiver TEXT NOT NULL,
+    redeemed BOOLEAN NOT NULL DEFAULT FALSE
+);
+
+CREATE INDEX idx_fees_mint ON fees(mint);
+CREATE INDEX idx_fees_amount ON fees(amount);

--- a/src/schema.rs
+++ b/src/schema.rs
@@ -1,0 +1,25 @@
+// @generated automatically by Diesel CLI.
+
+diesel::table! {
+    fees (id) {
+        id -> Int4,
+        tx_hash -> Text,
+        mint -> Text,
+        amount -> Numeric,
+        blinder -> Numeric,
+        receiver -> Text,
+        redeemed -> Bool,
+    }
+}
+
+diesel::table! {
+    indexing_metadata (key) {
+        key -> Text,
+        value -> Text,
+    }
+}
+
+diesel::allow_tables_to_appear_in_same_query!(
+    fees,
+    indexing_metadata,
+);


### PR DESCRIPTION
### Purpose
This PR sets up a diesel migration directory and adds two migrations which:

1. Add the indexing_metadata table
2. Add the fees table with indices on the mint and amount fields

### Testing
Applied the migrations against the DB