### PR TITLE
migrations, schema: Add a `wallets` table for tracking fee wallet info

### DIFF
--- a/migrations/2024-06-16-003335_create_wallets_table/down.sql
+++ b/migrations/2024-06-16-003335_create_wallets_table/down.sql
@@ -1,0 +1,2 @@
+-- Drop the wallets table
+DROP TABLE IF EXISTS wallets;

--- a/migrations/2024-06-16-003335_create_wallets_table/up.sql
+++ b/migrations/2024-06-16-003335_create_wallets_table/up.sql
@@ -1,0 +1,7 @@
+-- Create a table for storing wallets and the mints they hold
+-- The `secret_id` is the id of the AWS Secrets Manager secret that holds recovery information for the wallet
+CREATE TABLE wallets (
+    id UUID PRIMARY KEY,
+    mints TEXT[],
+    secret_id TEXT
+);

--- a/src/main.rs
+++ b/src/main.rs
@@ -12,6 +12,7 @@ pub mod schema;
 
 use diesel::{pg::PgConnection, Connection};
 use ethers::signers::LocalWallet;
+use models::Metadata;
 use renegade_circuit_types::elgamal::DecryptionKey;
 use renegade_util::telemetry::{setup_system_logger, LevelFilter};
 

--- a/src/schema.rs
+++ b/src/schema.rs
@@ -19,4 +19,16 @@ diesel::table! {
     }
 }
 
-diesel::allow_tables_to_appear_in_same_query!(fees, indexing_metadata,);
+diesel::table! {
+    wallets (id) {
+        id -> Uuid,
+        mints -> Nullable<Array<Nullable<Text>>>,
+        secret_id -> Nullable<Text>,
+    }
+}
+
+diesel::allow_tables_to_appear_in_same_query!(
+    fees,
+    indexing_metadata,
+    wallets,
+);


### PR DESCRIPTION
### Purpose
This PR adds a `wallets` table that tracks all wallets owned by the fee redeemer. This table does not store the key/recovery information for the wallets, but instead stores a reference to the AWS SM entry in which this information can be found. The fee sweeper will use these wallets to redeem fees into and withdraw fee takes from.

### Testing
- Applied the migration against the sweeper's DB