### PR TITLE
indexer: redeem-fees: Redeem fees into wallet through relayer

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,7 +11,7 @@ tokio = { version = "1.10", features = ["full"] }
 # === Infra === #
 aws-sdk-secretsmanager = "1.37"
 aws-config = "1.5"
-diesel = { version = "2.1", features = ["postgres", "numeric", "uuid"] }
+diesel = { version = "2.2", features = ["postgres", "numeric", "uuid"] }
 
 # === Blockchain Interaction === #
 alloy-sol-types = "0.3.1"
@@ -31,7 +31,7 @@ renegade-util = { package = "util", git = "https://github.com/renegade-fi/renega
 
 # === Misc Dependencies === #
 base64 = "0.22"
-bigdecimal = { version = "0.3", features = ["serde"] }
+bigdecimal = { version = "0.4", features = ["serde"] }
 futures = "0.3"
 http = "1.1"
 num-bigint = "0.4"

--- a/src/indexer/mod.rs
+++ b/src/indexer/mod.rs
@@ -1,6 +1,6 @@
 //! The indexer handles the indexing and redemption of fee notes
 
-use arbitrum_client::client::ArbitrumClient;
+use arbitrum_client::{client::ArbitrumClient, constants::Chain};
 use aws_config::SdkConfig as AwsConfig;
 use diesel::PgConnection;
 use renegade_circuit_types::elgamal::DecryptionKey;
@@ -13,8 +13,10 @@ pub mod redeem_fees;
 
 /// Stores the dependencies needed to index the chain
 pub(crate) struct Indexer {
-    /// The environment this indexer runs in
-    pub env: String,
+    /// The id of the chain this indexer targets
+    pub chain_id: u64,
+    /// The chain this indexer targets
+    pub chain: Chain,
     /// A client for interacting with the relayer
     pub relayer_client: RelayerClient,
     /// The Arbitrum client
@@ -30,7 +32,8 @@ pub(crate) struct Indexer {
 impl Indexer {
     /// Constructor
     pub fn new(
-        env: String,
+        chain_id: u64,
+        chain: Chain,
         aws_config: AwsConfig,
         arbitrum_client: ArbitrumClient,
         decryption_key: DecryptionKey,
@@ -38,7 +41,8 @@ impl Indexer {
         relayer_client: RelayerClient,
     ) -> Self {
         Indexer {
-            env,
+            chain_id,
+            chain,
             arbitrum_client,
             decryption_key,
             db_conn,

--- a/src/indexer/queries.rs
+++ b/src/indexer/queries.rs
@@ -17,7 +17,9 @@ use renegade_util::raw_err_str;
 use crate::db::models::WalletMetadata;
 use crate::db::models::{Metadata, NewFee};
 use crate::db::schema::{
-    fees::dsl::{fees as fees_table, mint as mint_col, redeemed as redeemed_col},
+    fees::dsl::{
+        fees as fees_table, mint as mint_col, redeemed as redeemed_col, tx_hash as tx_hash_col,
+    },
     indexing_metadata::dsl::{
         indexing_metadata as metadata_table, key as metadata_key, value as metadata_value,
     },
@@ -119,12 +121,23 @@ impl Indexer {
         Ok(mints)
     }
 
+    /// Mark a fee as redeemed
+    pub(crate) fn mark_fee_as_redeemed(&mut self, tx_hash: &str) -> Result<(), String> {
+        let filter = tx_hash_col.eq(tx_hash);
+        diesel::update(fees_table.filter(filter))
+            .set(redeemed_col.eq(true))
+            .execute(&mut self.db_conn)
+            .map_err(raw_err_str!("failed to mark fee as redeemed: {}"))
+            .map(|_| ())
+    }
+
     /// Get the most valuable fees to be redeemed
     ///
     /// Returns the tx hashes of the most valuable fees to be redeemed
     pub(crate) fn get_most_valuable_fees(
         &mut self,
         prices: HashMap<String, f64>,
+        receiver: &str,
     ) -> Result<Vec<FeeValue>, String> {
         if prices.is_empty() {
             return Ok(vec![]);
@@ -150,7 +163,10 @@ impl Indexer {
             query_string.push_str(&format!("WHEN mint = '{}' then amount * {} ", mint, price));
         }
         query_string.push_str("ELSE 0 END as value ");
-        query_string.push_str("FROM fees WHERE redeemed = false ");
+        query_string.push_str(&format!(
+            "FROM fees WHERE redeemed = false and receiver = '{}'",
+            receiver
+        ));
 
         // Sort and limit
         query_string.push_str(&format!("ORDER BY value DESC LIMIT {};", MAX_FEES_REDEEMED));

--- a/src/indexer/queries.rs
+++ b/src/indexer/queries.rs
@@ -56,6 +56,7 @@ pub(crate) struct FeeValue {
     pub mint: String,
     /// The value of the fee
     #[sql_type = "Numeric"]
+    #[allow(unused)]
     pub value: BigDecimal,
 }
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -15,7 +15,10 @@ use ethers::signers::LocalWallet;
 use indexer::Indexer;
 use relayer_client::RelayerClient;
 use renegade_circuit_types::elgamal::DecryptionKey;
-use renegade_util::telemetry::{setup_system_logger, LevelFilter};
+use renegade_util::{
+    raw_err_str,
+    telemetry::{setup_system_logger, LevelFilter},
+};
 
 use std::{error::Error, str::FromStr};
 
@@ -41,9 +44,6 @@ const DEFAULT_REGION: &str = "us-east-2";
 /// The cli for the fee sweeper
 #[derive(Debug, Parser)]
 struct Cli {
-    /// The environment this sweeper runs in
-    #[clap(short, long, default_value = "testnet")]
-    env: String,
     /// The URL of the relayer to use
     #[clap(long)]
     relayer_url: String,
@@ -100,11 +100,23 @@ async fn main() -> Result<(), Box<dyn Error>> {
         block_polling_interval_ms: BLOCK_POLLING_INTERVAL_MS,
     };
     let client = ArbitrumClient::new(conf).await?;
+    let chain_id = client
+        .chain_id()
+        .await
+        .map_err(raw_err_str!("Error fetching chain ID: {}"))?;
 
     // Build the indexer
     let key = DecryptionKey::from_hex_str(&cli.decryption_key)?;
     let relayer_client = RelayerClient::new(&cli.relayer_url, &cli.usdc_mint);
-    let mut indexer = Indexer::new(cli.env, config, client, key, db_conn, relayer_client);
+    let mut indexer = Indexer::new(
+        chain_id,
+        cli.chain,
+        config,
+        client,
+        key,
+        db_conn,
+        relayer_client,
+    );
 
     // 1. Index all new fees in the DB
     indexer.index_fees().await?;


### PR DESCRIPTION
### Purpose
This PR redeems fees into redemption wallets through the relayer's `redeem-note` API.

### Todo
- Better handle task failures
- Mark notes as redeemed if nullifier is then seen on-chain

### Testing
- Tested against a devnet relayer running locally